### PR TITLE
chore: update packages and bump version to 1.1.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.1.1</VersionPrefix>
+        <VersionPrefix>1.1.2</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/samples/Sample7/Sample7.csproj
+++ b/samples/Sample7/Sample7.csproj
@@ -2,8 +2,8 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\AWSSecretsManager.Provider\AWSSecretsManager.Provider.csproj" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/AWSSecretsManager.Provider/AWSSecretsManager.Provider.csproj
+++ b/src/AWSSecretsManager.Provider/AWSSecretsManager.Provider.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.0.15" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
-    <PackageReference Include="System.Text.Json" Version="9.0.7" />
-    <PackageReference Include="LayeredCraft.StructuredLogging" Version="1.1.0.7" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.0.20" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+    <PackageReference Include="System.Text.Json" Version="9.0.8" />
+    <PackageReference Include="LayeredCraft.StructuredLogging" Version="1.1.1.8" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="" Visible="false" />

--- a/tests/AWSSecretsManager.Provider.Tests/AWSSecretsManager.Provider.Tests.csproj
+++ b/tests/AWSSecretsManager.Provider.Tests/AWSSecretsManager.Provider.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+    <PackageReference Include="xunit.v3" Version="3.0.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Updates all NuGet packages to their latest versions
- Bumps version to 1.1.2 in Directory.Build.props
- Updates AWS SDK, Microsoft.Extensions, System.Text.Json, and test packages

## Package Updates
- **AWSSDK.SecretsManager**: 4.0.0.15 → 4.0.0.20
- **Microsoft.Extensions.Configuration**: 9.0.7 → 9.0.8  
- **Microsoft.Extensions.Logging.Abstractions**: 9.0.7 → 9.0.8
- **Microsoft.Extensions.Logging**: 9.0.7 → 9.0.8
- **Microsoft.Extensions.Logging.Console**: 9.0.7 → 9.0.8
- **System.Text.Json**: 9.0.7 → 9.0.8
- **LayeredCraft.StructuredLogging**: 1.1.0.7 → 1.1.1.8
- **xunit.v3**: 3.0.0 → 3.0.1
- **xunit.runner.visualstudio**: 3.1.3 → 3.1.4

## Test plan
- [ ] Build passes on all target frameworks
- [ ] All tests continue to pass
- [ ] No breaking API changes introduced

🤖 Generated with [Claude Code](https://claude.ai/code)