### PR TITLE
fix: match secrets by name/partial ARN in batch fetch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.1.9</VersionPrefix>
+        <VersionPrefix>1.2.0</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/src/AWSSecretsManager.Provider/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/AWSSecretsManager.Provider/Internal/SecretsManagerConfigurationProvider.cs
@@ -407,10 +407,18 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
                     resultSet.Add(secretValueSet);
                 } while (!string.IsNullOrWhiteSpace(secretValueSet.NextToken));
 
-                foreach (var (secretValue, secret) in
-                         resultSet.SelectMany(a => a.SecretValues.Select(b => b))
-                             .Join(secretSet, a => a.ARN, b => b.ARN, (a, b) => (a, b)))
+                foreach (var secretValue in resultSet.SelectMany(a => a.SecretValues))
                 {
+                    // Match the returned secret back to our input list using flexible ARN/name comparison.
+                    // AWS returns full ARNs (with a random suffix like "-AbCdEf") even when the caller
+                    // supplied a short name or partial ARN, so exact equality on ARN alone would silently
+                    // drop every result when AcceptedSecretArns contains anything other than full ARNs.
+                    var secret = secretSet.FirstOrDefault(s =>
+                        s.ARN.Equals(secretValue.ARN, StringComparison.OrdinalIgnoreCase) ||
+                        secretValue.ARN.EndsWith(s.ARN, StringComparison.OrdinalIgnoreCase) ||
+                        s.ARN.Equals(secretValue.Name, StringComparison.OrdinalIgnoreCase));
+
+                    if (secret == null) continue;
 
                     var secretEntry = Options.AcceptedSecretArns.Count > 0
                         ? new SecretListEntry

--- a/tests/AWSSecretsManager.Provider.Tests/Internal/SecretsManagerConfigurationProviderTests.cs
+++ b/tests/AWSSecretsManager.Provider.Tests/Internal/SecretsManagerConfigurationProviderTests.cs
@@ -466,4 +466,106 @@ public class SecretsManagerConfigurationProviderTests
         sut.Get(testEntry.Name, nameof(RootObject.Mid), nameof(MidLevel.Leaf), nameof(Leaf.Property))
             .Should().Be(test.Mid.Leaf.Property);
     }
+
+    // Partial ARN matching tests
+    // When AcceptedSecretArns contains short names or partial ARNs, AWS Secrets Manager returns the
+    // full ARN (with a random "-AbCdEf" suffix) in the BatchGetSecretValue response. The previous
+    // exact-equality join on ARN silently dropped every result in those cases.
+
+    [Theory, CustomAutoData]
+    public void Batch_fetch_with_accepted_secret_names_should_match_returned_secrets(
+        [Frozen] IAmazonSecretsManager secretsManager,
+        [Frozen] SecretsManagerConfigurationProviderOptions options,
+        SecretsManagerConfigurationProvider sut,
+        IFixture fixture)
+    {
+        const string secretName = "MyTestSecret";
+        var fullArn = $"arn:aws:secretsmanager:us-east-1:123456789012:secret:{secretName}-AbCdEf";
+        const string secretValue = "test-value";
+
+        var batchResponse = fixture.Build<BatchGetSecretValueResponse>()
+            .With(p => p.SecretValues, new List<SecretValueEntry>
+            {
+                new SecretValueEntry { ARN = fullArn, Name = secretName, SecretString = secretValue }
+            })
+            .Without(p => p.Errors)
+            .Without(p => p.NextToken)
+            .Create();
+
+        secretsManager.BatchGetSecretValueAsync(Arg.Any<BatchGetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(batchResponse));
+
+        options.UseBatchFetch = true;
+        options.AcceptedSecretArns = new List<string> { secretName };
+
+        sut.Load();
+
+        secretsManager.DidNotReceive().ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>());
+        sut.Get(secretName).Should().Be(secretValue);
+    }
+
+    [Theory, CustomAutoData]
+    public void Batch_fetch_with_accepted_partial_arns_should_match_returned_secrets(
+        [Frozen] IAmazonSecretsManager secretsManager,
+        [Frozen] SecretsManagerConfigurationProviderOptions options,
+        SecretsManagerConfigurationProvider sut,
+        IFixture fixture)
+    {
+        const string secretName = "MyTestSecret";
+        const string partialArn = $"{secretName}-AbCdEf";
+        var fullArn = $"arn:aws:secretsmanager:us-east-1:123456789012:secret:{partialArn}";
+        const string secretValue = "test-value";
+
+        var batchResponse = fixture.Build<BatchGetSecretValueResponse>()
+            .With(p => p.SecretValues, new List<SecretValueEntry>
+            {
+                new SecretValueEntry { ARN = fullArn, Name = secretName, SecretString = secretValue }
+            })
+            .Without(p => p.Errors)
+            .Without(p => p.NextToken)
+            .Create();
+
+        secretsManager.BatchGetSecretValueAsync(Arg.Any<BatchGetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(batchResponse));
+
+        options.UseBatchFetch = true;
+        options.AcceptedSecretArns = new List<string> { partialArn };
+
+        sut.Load();
+
+        secretsManager.DidNotReceive().ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>());
+        sut.Get(secretName).Should().Be(secretValue);
+    }
+
+    [Theory, CustomAutoData]
+    public void Batch_fetch_with_accepted_full_arns_should_match_returned_secrets(
+        [Frozen] IAmazonSecretsManager secretsManager,
+        [Frozen] SecretsManagerConfigurationProviderOptions options,
+        SecretsManagerConfigurationProvider sut,
+        IFixture fixture)
+    {
+        const string secretName = "MyTestSecret";
+        var fullArn = $"arn:aws:secretsmanager:us-east-1:123456789012:secret:{secretName}-AbCdEf";
+        const string secretValue = "test-value";
+
+        var batchResponse = fixture.Build<BatchGetSecretValueResponse>()
+            .With(p => p.SecretValues, new List<SecretValueEntry>
+            {
+                new SecretValueEntry { ARN = fullArn, Name = secretName, SecretString = secretValue }
+            })
+            .Without(p => p.Errors)
+            .Without(p => p.NextToken)
+            .Create();
+
+        secretsManager.BatchGetSecretValueAsync(Arg.Any<BatchGetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(batchResponse));
+
+        options.UseBatchFetch = true;
+        options.AcceptedSecretArns = new List<string> { fullArn };
+
+        sut.Load();
+
+        secretsManager.DidNotReceive().ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>());
+        sut.Get(secretName).Should().Be(secretValue);
+    }
 }


### PR DESCRIPTION
## Problem

`FetchConfigurationBatchAsync` uses `.Join(secretSet, a => a.ARN, b => b.ARN, ...)` to correlate the `BatchGetSecretValue` response back to the input list. AWS always returns **full ARNs** in the response (e.g. `arn:…:secret:MySecret-AbCdEf`) regardless of what the caller supplied, so the join produces zero matches whenever `AcceptedSecretArns` contains short names or partial ARNs. The result is silent — no error is raised, but no configuration is loaded.

Fixes #66.

## Prior art

This same bug was reported and fixed in the library this project was forked from:
- Issue: Kralizek/AWSSecretsManagerConfigurationExtensions#101
- PR: Kralizek/AWSSecretsManagerConfigurationExtensions#102

## Solution

Replace the `.Join` with a `FirstOrDefault` that accepts three forms of match:

```csharp
var secret = secretSet.FirstOrDefault(s =>
    s.ARN.Equals(secretValue.ARN, StringComparison.OrdinalIgnoreCase) ||   // full ARN (existing behaviour)
    secretValue.ARN.EndsWith(s.ARN, StringComparison.OrdinalIgnoreCase) || // partial ARN / name+suffix
    s.ARN.Equals(secretValue.Name, StringComparison.OrdinalIgnoreCase));   // short name
```

## Tests

Three new `[Theory]` tests in `SecretsManagerConfigurationProviderTests` cover all three input forms:
- short name (`"MySecret"`)
- partial ARN (`"MySecret-AbCdEf"`)
- full ARN (`"arn:…:secret:MySecret-AbCdEf"`) — ensures no regression on the existing happy path