### PR TITLE
fix: handle JSON null values in secrets without throwing FormatException

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.2.0</VersionPrefix>
+        <VersionPrefix>1.2.1</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,15 +3,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="AWS SDK">
-    <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.4.6" />
+    <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.4.15" />
   </ItemGroup>
   <ItemGroup Label="LayeredCraft">
     <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.1.7.18" />
   </ItemGroup>
   <ItemGroup Label="Microsoft">
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
   </ItemGroup>
   <!--
     NOTE: This repo intentionally pins Microsoft.Extensions.Configuration by TFM.
@@ -21,18 +21,18 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.14" />
   </ItemGroup>
   <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.4.1" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />

--- a/src/AWSSecretsManager.Provider/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/AWSSecretsManager.Provider/Internal/SecretsManagerConfigurationProvider.cs
@@ -29,7 +29,7 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
     public IAmazonSecretsManager Client { get; }
 
     private readonly ILogger? _logger;
-    private HashSet<(string, string)> _loadedValues = new();
+    private HashSet<(string, string?)> _loadedValues = new();
     private Task? _pollingTask;
     private CancellationTokenSource? _cancellationToken;
 
@@ -197,7 +197,7 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
         }
     }
 
-    private static IEnumerable<(string key, string value)> ExtractValues(JsonElement? jsonElement, string prefix)
+    private static IEnumerable<(string key, string? value)> ExtractValues(JsonElement? jsonElement, string prefix)
     {
         if (jsonElement == null)
         {
@@ -233,11 +233,6 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
                 break;
             }
             case JsonValueKind.True:
-            {
-                var value = element.GetBoolean();
-                yield return (prefix, value.ToString());
-                break;
-            }
             case JsonValueKind.False:
             {
                 var value = element.GetBoolean();
@@ -256,8 +251,12 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
                 }
                 break;
             }
-            case JsonValueKind.Undefined:
             case JsonValueKind.Null:
+            {
+                yield return (prefix, null);
+                break;
+            }
+            case JsonValueKind.Undefined:
             default:
             {
                 throw new FormatException("unsupported json token");
@@ -265,9 +264,9 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
         }
     }
 
-    private void SetData(IEnumerable<(string, string)> values, bool triggerReload)
+    private void SetData(IEnumerable<(string, string?)> values, bool triggerReload)
     {
-        Data = values.ToDictionary<(string, string), string, string?>(x => x.Item1, x => x.Item2, StringComparer.InvariantCultureIgnoreCase);
+        Data = values.ToDictionary<(string, string?), string, string?>(x => x.Item1, x => x.Item2, StringComparer.InvariantCultureIgnoreCase);
         if (triggerReload)
         {
             OnReload();
@@ -298,10 +297,10 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
         return result;
     }
 
-    private async Task<HashSet<(string, string)>> FetchConfigurationAsync(CancellationToken cancellationToken)
+    private async Task<HashSet<(string, string?)>> FetchConfigurationAsync(CancellationToken cancellationToken)
     {
         var secrets = await FetchAllSecretsAsync(cancellationToken).ConfigureAwait(false);
-        var configuration = new HashSet<(string, string)>();
+        var configuration = new HashSet<(string, string?)>();
         foreach (var secret in secrets)
         {
             try
@@ -374,10 +373,10 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
             .ToList();
     }
 
-    private async Task<HashSet<(string, string)>> FetchConfigurationBatchAsync(CancellationToken cancellationToken)
+    private async Task<HashSet<(string, string?)>> FetchConfigurationBatchAsync(CancellationToken cancellationToken)
     {
         var secrets = await FetchAllSecretsAsync(cancellationToken).ConfigureAwait(false);
-        var configuration = new HashSet<(string, string)>();
+        var configuration = new HashSet<(string, string?)>();
         var chunked = ChunkList(secrets, Options.SecretFilter, 20);
         foreach (var secretSet in chunked)
         {

--- a/tests/AWSSecretsManager.Provider.Tests/Internal/SecretsManagerConfigurationProviderTests.cs
+++ b/tests/AWSSecretsManager.Provider.Tests/Internal/SecretsManagerConfigurationProviderTests.cs
@@ -568,4 +568,86 @@ public class SecretsManagerConfigurationProviderTests
         secretsManager.DidNotReceive().ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>());
         sut.Get(secretName).Should().Be(secretValue);
     }
+
+    // JSON null value handling tests
+    // Previously, JsonValueKind.Null was grouped with JsonValueKind.Undefined and threw FormatException.
+    // The fix correctly maps null JSON values to null configuration entries.
+
+    [Theory, CustomAutoData]
+    public void JSON_with_null_property_value_should_not_throw([Frozen] SecretListEntry testEntry,
+        ListSecretsResponse listSecretsResponse, [Frozen] IAmazonSecretsManager secretsManager,
+        SecretsManagerConfigurationProvider sut, IFixture fixture)
+    {
+        var getSecretValueResponse = fixture.Build<GetSecretValueResponse>()
+            .With(p => p.SecretString, """{"Key": null}""")
+            .Without(p => p.SecretBinary)
+            .Create();
+
+        secretsManager.ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(listSecretsResponse));
+
+        secretsManager.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(getSecretValueResponse));
+
+        var loadAction = () => sut.Load();
+        loadAction.Should().NotThrow();
+
+        sut.HasKey(testEntry.Name, "Key").Should().BeTrue();
+        sut.Get(testEntry.Name, "Key").Should().BeNull();
+    }
+
+    [Theory, CustomAutoData]
+    public void JSON_with_nested_null_property_value_should_not_throw([Frozen] SecretListEntry testEntry,
+        ListSecretsResponse listSecretsResponse, [Frozen] IAmazonSecretsManager secretsManager,
+        SecretsManagerConfigurationProvider sut, IFixture fixture)
+    {
+        var getSecretValueResponse = fixture.Build<GetSecretValueResponse>()
+            .With(p => p.SecretString, """{"Parent": {"Child": null}}""")
+            .Without(p => p.SecretBinary)
+            .Create();
+
+        secretsManager.ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(listSecretsResponse));
+
+        secretsManager.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(getSecretValueResponse));
+
+        var loadAction = () => sut.Load();
+        loadAction.Should().NotThrow();
+
+        sut.HasKey(testEntry.Name, "Parent", "Child").Should().BeTrue();
+        sut.Get(testEntry.Name, "Parent", "Child").Should().BeNull();
+    }
+
+    [Theory, CustomAutoData]
+    public void Batch_fetch_JSON_with_null_property_value_should_not_throw(
+        [Frozen] IAmazonSecretsManager secretsManager,
+        [Frozen] SecretsManagerConfigurationProviderOptions options,
+        SecretsManagerConfigurationProvider sut,
+        IFixture fixture)
+    {
+        const string secretName = "MySecret";
+        const string fullArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:MySecret-AbCdEf";
+
+        var batchResponse = fixture.Build<BatchGetSecretValueResponse>()
+            .With(p => p.SecretValues, new List<SecretValueEntry>
+            {
+                new SecretValueEntry { ARN = fullArn, Name = secretName, SecretString = """{"Key": null}""" }
+            })
+            .Without(p => p.Errors)
+            .Without(p => p.NextToken)
+            .Create();
+
+        secretsManager.BatchGetSecretValueAsync(Arg.Any<BatchGetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(batchResponse));
+
+        options.UseBatchFetch = true;
+        options.AcceptedSecretArns = new List<string> { fullArn };
+
+        var loadAction = () => sut.Load();
+        loadAction.Should().NotThrow();
+
+        sut.HasKey(secretName, "Key").Should().BeTrue();
+        sut.Get(secretName, "Key").Should().BeNull();
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #74. JSON secrets containing `null` property values (e.g. `{"Key": null}`) previously caused a `FormatException("unsupported json token")` to be thrown during load. `JsonValueKind.Null` was incorrectly grouped with `JsonValueKind.Undefined` in `ExtractValues`. The fix separates the two cases: `Null` now yields a `null` configuration value, while `Undefined` still throws. Internal tuple types are updated from `(string, string)` to `(string, string?)` throughout the fetch/load pipeline to support this.

## Changes

**Bug fix — `SecretsManagerConfigurationProvider.cs`**
- `JsonValueKind.Null` now yields `(prefix, null)` instead of throwing
- `JsonValueKind.True` and `False` cases consolidated (no behavior change)
- `_loadedValues`, `FetchConfigurationAsync`, `FetchConfigurationBatchAsync`, `ExtractValues`, and `SetData` updated to use `(string, string?)` tuples

**Tests — `SecretsManagerConfigurationProviderTests.cs`**
- `JSON_with_null_property_value_should_not_throw` — flat JSON null via regular fetch
- `JSON_with_nested_null_property_value_should_not_throw` — nested JSON null via regular fetch
- `Batch_fetch_JSON_with_null_property_value_should_not_throw` — JSON null via batch fetch

**Version & dependencies — `Directory.Build.props` / `Directory.Packages.props`**
- `VersionPrefix` bumped `1.2.0` → `1.2.1`
- `AWSSDK.SecretsManager` 4.0.4.6 → 4.0.4.15
- `Microsoft.Extensions.Logging*` 10.0.3 → 10.0.5
- `Microsoft.Extensions.Configuration` (net9) 9.0.13 → 9.0.14; (net10) 10.0.3 → 10.0.5
- `AwesomeAssertions` 9.3.0 → 9.4.0; test SDK packages updated

## Validation

- `dotnet build` — 0 errors, 36 pre-existing warnings
- `dotnet run --framework net8.0` (tests) — **62/62 passed** (includes the 3 new null-value tests)
- No breaking changes: the previous behavior was a crash; the new behavior is correct null propagation

## Related Issues

Fixes #74

## Release Notes

**v1.2.1** — JSON secrets with `null` property values no longer throw `FormatException`. Null JSON values are now stored as null entries in the configuration dictionary, consistent with how other .NET configuration providers handle absent values.