### PR TITLE
fix: remove unnecessary CreatedDate assignment from synthetic SecretListEntry

### DIFF
--- a/src/AWSSecretsManager.Provider/Internal/SecretsManagerConfigurationProvider.cs
+++ b/src/AWSSecretsManager.Provider/Internal/SecretsManagerConfigurationProvider.cs
@@ -324,8 +324,7 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
                     ? new SecretListEntry
                     {
                         ARN = secret.ARN,
-                        Name = secretValue.Name,
-                        CreatedDate = secretValue.CreatedDate
+                        Name = secretValue.Name
                     }
                     : secret;
 
@@ -423,8 +422,7 @@ public class SecretsManagerConfigurationProvider : ConfigurationProvider, IDispo
                         ? new SecretListEntry
                         {
                             ARN = secret.ARN,
-                            Name = secretValue.Name,
-                            CreatedDate = secretValue.CreatedDate
+                            Name = secretValue.Name
                         }
                         : secret;
 


### PR DESCRIPTION
## Summary

- Remove `CreatedDate = secretValue.CreatedDate` assignments in `FetchConfigurationAsync` and `FetchConfigurationBatchAsync` when constructing synthetic `SecretListEntry` objects

## Problem

When `AcceptedSecretArns` is configured, the provider creates synthetic `SecretListEntry` objects and copies `CreatedDate` from `GetSecretValueResponse`. This property is never consumed downstream — the `KeyGenerator` callback only receives `Name` and the key string.

The compiled IL references `GetSecretValueResponse.get_CreatedDate()` with a specific return type. If a consumer's project resolves a different major version of `AWSSDK.SecretsManager` than the provider was compiled against (e.g., v3's `DateTime` vs v4's `DateTime?`), this causes a `MissingMethodException` at runtime:

```
System.MissingMethodException: Method not found:
  'System.DateTime Amazon.SecretsManager.Model.GetSecretValueResponse.get_CreatedDate()'
```

## Fix

Remove the unnecessary `CreatedDate` assignment entirely. This eliminates the method reference from the IL, avoiding the binary incompatibility without any functional impact.

## Test plan

- [x] Build succeeds across all TFMs (netstandard2.0, net8.0, net9.0, net10.0)
- [ ] Existing tests pass in CI (cannot run locally due to .NET 10 SDK + VSTest incompatibility)
- [x] Verified `KeyGenerator` does not use `CreatedDate` from the `SecretListEntry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)