### PR TITLE
build: add net11 targeting and refresh workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,13 +11,12 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/package-build.yaml@v6.2
+    uses: LayeredCraft/devops-templates/.github/workflows/package-build.yaml@v7.6
     with:
       dotnet-version: |
         8.0.x
         9.0.x
         10.0.x
+        11.0.x
       hasTests: true
-      useMtpRunner: true
-      testDirectory: "tests"
     secrets: inherit

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -18,5 +18,6 @@ jobs:
         11.0.x
       runCdk: false
       enableCodeCoverage: true
+      useMtpRunner: true
       coverageThreshold: 70
     secrets: inherit

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -7,7 +7,7 @@ on:
 permissions: write-all
 jobs:
   build:
-    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v6.2
+    uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v7.6
     with:
       solution: AWSSecretsManager.slnx
       hasTests: true
@@ -15,9 +15,8 @@ jobs:
         8.0.x
         9.0.x
         10.0.x
+        11.0.x
       runCdk: false
-      useMtpRunner: true
-      testDirectory: "tests"
       enableCodeCoverage: true
       coverageThreshold: 70
     secrets: inherit

--- a/AWSSecretsManager.slnx
+++ b/AWSSecretsManager.slnx
@@ -34,6 +34,7 @@
   <Folder Name="/Solution Items/">
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
+    <File Path="global.json" />
     <File Path="icon.png" />
     <File Path="LICENSE" />
     <File Path="NOTICE" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>1.2.1</VersionPrefix>
+        <VersionPrefix>1.3.0</VersionPrefix>
         <!-- SPDX license identifier for Apache 2.0 -->
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,15 +3,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="AWS SDK">
-    <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.4.15" />
+    <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.4.17" />
   </ItemGroup>
   <ItemGroup Label="LayeredCraft">
-    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.1.7.18" />
+    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.1.8.20" />
   </ItemGroup>
   <ItemGroup Label="Microsoft">
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
   </ItemGroup>
   <!--
     NOTE: This repo intentionally pins Microsoft.Extensions.Configuration by TFM.
@@ -21,18 +21,21 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.15" />
   </ItemGroup>
   <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
+  </ItemGroup>
+  <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net11.0'">
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="11.0.0-preview.3.26207.106" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/AWSSecretsManager.Provider/AWSSecretsManager.Provider.csproj
+++ b/src/AWSSecretsManager.Provider/AWSSecretsManager.Provider.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>default</LangVersion>
 	<Nullable>enable</Nullable>  
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <PackageId>AWSSecretsManager.Provider</PackageId>
     <Title>AWSSecretsManager.Provider</Title>
     <Description>An AWS Secrets Manager-backed configuration provider for .NET applications using Microsoft.Extensions.Configuration.</Description>

--- a/tests/AWSSecretsManager.Provider.Tests/AWSSecretsManager.Provider.Tests.csproj
+++ b/tests/AWSSecretsManager.Provider.Tests/AWSSecretsManager.Provider.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
This updates the library and test projects to target `net11.0`, refreshes central package versions, and moves the GitHub Actions workflows onto the newer shared templates that understand the current test setup. The change keeps `global.json` focused on Microsoft Testing Platform configuration so the repo can build and test against the installed preview SDK without pinning a specific SDK version.

## Changes
- add `net11.0` to the provider and test project target frameworks
- update centrally managed package versions, including AWS SDK, logging, configuration, and test packages
- upgrade the shared GitHub Actions workflow templates to `v7.6` and include `11.0.x` in the matrix
- add `global.json` to the solution items and remove the pinned SDK block so local and CI preview SDKs can roll forward naturally

## Validation
- `dotnet build`
- `dotnet run --framework net8.0` in `tests/AWSSecretsManager.Provider.Tests`
- `dotnet run --framework net9.0` in `tests/AWSSecretsManager.Provider.Tests`
- `dotnet run --framework net10.0` in `tests/AWSSecretsManager.Provider.Tests`
- `dotnet run --framework net11.0` in `tests/AWSSecretsManager.Provider.Tests`

## Release Notes
- add `net11.0` targeting support and align CI/package dependencies with the updated toolchain