### PR TITLE
fix(ci): add permissions to pr-title-check and bump StructuredLogging to 1.2.0

### DIFF
--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  pull-requests: read
+  statuses: write
+
 jobs:
   validate:
     uses: LayeredCraft/devops-templates/.github/workflows/pr-title-check.yml@v8.0

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.4.17" />
   </ItemGroup>
   <ItemGroup Label="LayeredCraft">
-    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.1.8.20" />
+    <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup Label="Microsoft">
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />


### PR DESCRIPTION
## Summary

- Add missing `pull-requests: read` and `statuses: write` permissions to `pr-title-check.yaml` caller workflow
- Bump `LayeredCraft.StructuredLogging` from `1.1.8.20` to `1.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)