### PR TITLE
ci(github): configure dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,15 @@
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    open-pull-requests-limit: 25
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
 updates:
   - package-ecosystem: "nuget"
     directory: "/"
@@ -6,7 +17,28 @@ updates:
       interval: "weekly"
       day: "wednesday"
     open-pull-requests-limit: 25
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     groups:
-      dotnet:
+      dotnet-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
+      dotnet-major:
+        update-types:
+          - "major"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "infrastructure"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'LayeredCraft/aws-secrets-manager-provider'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AWSSecretsManager.slnx
+++ b/AWSSecretsManager.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/git/">
     <File Path=".github/dependabot.yml" />
+    <File Path=".github/workflows/dependabot-auto-merge.yml" />
     <File Path=".github/workflows/pr-build.yaml" />
     <File Path=".github/workflows/pr-title-check.yaml" />
     <File Path=".github/workflows/publish-preview.yaml" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,26 +8,29 @@
   <ItemGroup Label="LayeredCraft">
     <PackageVersion Include="LayeredCraft.StructuredLogging" Version="1.2.3" />
   </ItemGroup>
-  <ItemGroup Label="Microsoft">
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+  <ItemGroup Label="Microsoft Logging (net9.0)" Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="[9.0.17, 10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[9.0.17, 10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="[9.0.17, 10.0.0)" />
   </ItemGroup>
-  <!--
-    NOTE: This repo intentionally pins Microsoft.Extensions.Configuration by TFM.
-    This mirrors the conditional versions previously specified in AWSSecretsManager.Provider.csproj.
-  -->
+  <!-- Microsoft.Extensions.* packages ship parallel stable and preview build lines.
+       Pin each per-TargetFramework with bounded ranges so Dependabot can raise
+       lower bounds without crossing into the next major/preview line. -->
   <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[8.0.0, 9.0.0)" />
   </ItemGroup>
   <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[9.0.17, 10.0.0)" />
   </ItemGroup>
   <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[10.0.9, 11.0.0)" />
   </ItemGroup>
+  <!-- Lower bound is a prerelease, which causes NuGet to consider prerelease
+       candidates for this package ID. Use a letter-led prerelease marker on
+       the exclusive upper bound so the range stays below all 12.0.0 previews
+       as well as 12.0.0 stable. -->
   <ItemGroup Label="Microsoft (TFM pinned)" Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="11.0.0-preview.5.26302.115" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="[11.0.0-preview.5.26302.115, 12.0.0-a)" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="AutoFixture" Version="4.18.1" />


### PR DESCRIPTION
## Summary

Updates this repo's Dependabot configuration to match the newer LayeredCraft automation pattern. This adds grouped NuGet updates, GitHub Actions update coverage, and automatic approval/auto-merge for safe Dependabot patch and minor updates.

## Changes

- Expanded `.github/dependabot.yml` with cooldowns, conventional commit metadata, infrastructure multi-ecosystem grouping, separate NuGet minor/patch vs. major groups, and GitHub Actions updates.
- Added `.github/workflows/dependabot-auto-merge.yml` to auto-approve and enable squash auto-merge for Dependabot semver patch/minor PRs only.
- Converted conditional `Microsoft.Extensions.Configuration` package versions to bounded ranges so Dependabot can update lower bounds without crossing target-framework-specific major/preview lines.
- Aligned the sample-only `Microsoft.Extensions.Logging*` package versions to the repo's `net9.0` sample target with bounded ranges, avoiding conflicts with the new `Microsoft.Extensions.Configuration` range.
- Added the new workflow file to `AWSSecretsManager.slnx` under `/git/`.

## Validation

- Ran `dotnet restore AWSSecretsManager.slnx` successfully.
- Ran `dotnet build AWSSecretsManager.slnx --no-restore` successfully.
- Build completed with existing warnings; no errors.

## Notes for Reviewers

This repo does not currently have a docs workflow or uv-managed docs dependencies, so no `uv` Dependabot ecosystem entry was added.
